### PR TITLE
fix: add build step before npm publish in release workflow

### DIFF
--- a/.github/workflows/auto-minor-release.yml
+++ b/.github/workflows/auto-minor-release.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Install deps (for publish)
         run: npm ci --no-audit --no-fund --ignore-scripts
 
+      - name: Build TypeScript
+        run: npm run build
+
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Added explicit TypeScript build step before npm publish in the release workflow
- Fixes CI failure where npm publish couldn't find compiled JavaScript files

## Test plan
- [ ] CI workflow runs successfully
- [ ] npm package publishes with compiled JavaScript files

🤖 Generated with [Claude Code](https://claude.ai/code)