### PR TITLE
fix: install all dependencies for build step in release workflow

### DIFF
--- a/.github/workflows/auto-minor-release.yml
+++ b/.github/workflows/auto-minor-release.yml
@@ -72,7 +72,7 @@ jobs:
         if: steps.tag.outputs.exists == 'false'
 
       - name: Install deps (for publish)
-        run: npm ci --no-audit --no-fund --ignore-scripts
+        run: npm ci --no-audit --no-fund
 
       - name: Build TypeScript
         run: npm run build


### PR DESCRIPTION
## Summary
- Removed `--ignore-scripts` flag from npm ci to allow scripts to run
- This ensures TypeScript and other devDependencies are properly available for the build step

## Problem
The previous fix added a build step but TypeScript wasn't available because we were using `--ignore-scripts` which prevented proper dependency installation.

## Test plan
- [ ] CI workflow runs successfully
- [ ] TypeScript build completes without errors
- [ ] npm package publishes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)