### PR TITLE
feat: issue を severity レベルでグルーピング表示

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "get-sonar-feedback",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "get-sonar-feedback",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-sonar-feedback",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "A CLI tool to fetch SonarCloud feedback for pull requests",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- issues コマンドで issue を severity レベル順にグルーピング表示する機能を追加
- CRITICAL から優先的に修正できるように、優先度順で表示
- バージョンを 0.3.0 にアップデート

## 変更内容
- BLOCKER → CRITICAL → MAJOR → MINOR → INFO の順序でグループ化
- 各 severity グループごとにヘッダーを表示  
- 制限がある場合も優先度順に表示
- より多くの issue がある場合の表示メッセージを改善

## Test plan
- [ ] `get-sonar-feedback issues` コマンドを実行して severity ごとにグループ化されることを確認
- [ ] CRITICAL issue が最初に表示されることを確認
- [ ] `--limit` オプションで制限した場合も優先度順に表示されることを確認
- [ ] `--all` オプションですべての issue が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)