### PR TITLE
feat: add severity grouping to PR analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-sonar-feedback",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A CLI tool to fetch SonarCloud feedback for pull requests",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,8 +381,30 @@ class SonarCloudFeedback {
     console.log(`Debt Total: ${data.debtTotal || 0}`);
 
     if (data.total > 0) {
-      console.log("");
-      data.issues.forEach((issue) => {
+      this.displayGroupedIssues(data);
+    } else {
+      console.log(chalk.green("✅ No issues found."));
+    }
+  }
+
+  private displayGroupedIssues(data: IssuesResponse): void {
+    const issuesBySeverity = new Map<Severity, typeof data.issues>();
+    
+    data.issues.forEach(issue => {
+      const severity = this.normalizeSeverity(issue.severity);
+      if (!issuesBySeverity.has(severity)) {
+        issuesBySeverity.set(severity, []);
+      }
+      issuesBySeverity.get(severity)!.push(issue);
+    });
+
+    for (const severity of SonarCloudFeedback.SEVERITY_ORDER) {
+      const issues = issuesBySeverity.get(severity);
+      if (!issues || issues.length === 0) continue;
+
+      console.log(chalk.bold(`\n🔸 ${this.getSeverityColored(severity)} Issues:`));
+      
+      issues.forEach((issue) => {
         console.log(`Issue Key: ${issue.key}`);
         console.log(`Rule: ${issue.rule}`);
         console.log(`Severity: ${this.getSeverityColored(issue.severity)}`);
@@ -399,8 +421,6 @@ class SonarCloudFeedback {
         console.log(`Tags: ${tagsList}`);
         console.log("-".repeat(50));
       });
-    } else {
-      console.log(chalk.green("✅ No issues found."));
     }
   }
 
@@ -910,7 +930,7 @@ const program = new Command();
 program
   .name("get-sonar-feedback")
   .description("Fetch SonarCloud feedback")
-  .version("0.3.0");
+  .version("0.3.1");
 
 program
   .command("pr")


### PR DESCRIPTION
## Summary
- Added severity grouping to PR analysis command
- Issues are now displayed grouped by severity level: BLOCKER → CRITICAL → MAJOR → MINOR → INFO
- Version bump to 0.3.1

## Test plan
- [x] Build successfully
- [x] CLI commands work correctly
- [x] Grouping logic implemented following existing pattern from issues command

🤖 Generated with [Claude Code](https://claude.ai/code)