### PR TITLE
feat: pr で重複コードのファイル別・行別詳細を表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A CLI tool to fetch SonarCloud feedback for pull requests and project-wide analy
 - 🐛 Code issues detection
 - 🔒 Security hotspots analysis
 - 🔄 Code duplication metrics
+- 🔎 File-level and line-level duplication details when `new_duplicated_lines_density` fails
 - 📊 Test coverage reporting
 - 🔍 Auto-detect PR number from current git branch
 - 📦 JSON output for automation (`--json`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "get-sonar-feedback",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "get-sonar-feedback",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-sonar-feedback",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A CLI tool to fetch SonarCloud feedback for pull requests",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "dev": "ts-node src/index.ts",
     "prepublishOnly": "npm run build",
-    "test": "ts-node test/parseMeasureNumber.test.ts && ts-node test/coverage-utils.test.ts"
+    "test": "ts-node test/parseMeasureNumber.test.ts && ts-node test/coverage-utils.test.ts && ts-node test/duplication-utils.test.ts"
   },
   "keywords": [
     "sonarcloud",

--- a/src/duplication-utils.ts
+++ b/src/duplication-utils.ts
@@ -67,9 +67,15 @@ export function buildDuplicationFileDetailsUrl(
   return url.toString();
 }
 
-export function buildDuplicationBlocksUrl(componentKey: string): string {
+export function buildDuplicationBlocksUrl(
+  componentKey: string,
+  pullRequestId?: string
+): string {
   const url = new URL("https://sonarcloud.io/api/duplications/show");
   url.searchParams.set("key", componentKey);
+  if (pullRequestId) {
+    url.searchParams.set("pullRequest", pullRequestId);
+  }
   return url.toString();
 }
 

--- a/src/duplication-utils.ts
+++ b/src/duplication-utils.ts
@@ -1,0 +1,196 @@
+import { Measure, parseMeasureNumber } from "./measure-utils";
+
+export interface DuplicationComponentTreeResponse {
+  components: Array<{
+    key: string;
+    path?: string;
+    measures?: Measure[];
+  }>;
+}
+
+export interface DuplicationFileSummary {
+  key: string;
+  path: string;
+  newDuplicatedLinesDensity: number;
+  duplicatedLines: number;
+}
+
+interface SonarDuplicationFile {
+  key: string;
+  name?: string;
+}
+
+interface SonarDuplicationBlock {
+  from: number;
+  size: number;
+  _ref?: string;
+}
+
+interface SonarDuplicationGroup {
+  blocks: SonarDuplicationBlock[];
+}
+
+export interface DuplicationBlocksResponse {
+  duplications?: SonarDuplicationGroup[];
+  files?: Record<string, SonarDuplicationFile>;
+}
+
+export interface DuplicationRange {
+  startLine: number;
+  endLine: number;
+}
+
+export interface DuplicationBlockDetail {
+  range: DuplicationRange;
+  otherRange: DuplicationRange;
+  otherFileKey: string;
+  otherFilePath: string;
+  sameFile: boolean;
+  displayText: string;
+}
+
+export function buildDuplicationFileDetailsUrl(
+  projectKey: string,
+  organization: string,
+  pullRequestId: string,
+  pageSize: number
+): string {
+  const url = new URL("https://sonarcloud.io/api/measures/component_tree");
+  url.searchParams.set("component", projectKey);
+  url.searchParams.set("organization", organization);
+  url.searchParams.set("pullRequest", pullRequestId);
+  url.searchParams.set("metricKeys", "new_duplicated_lines_density,duplicated_lines");
+  url.searchParams.set("metricPeriod", "1");
+  url.searchParams.set("qualifiers", "FIL");
+  url.searchParams.set("ps", String(pageSize));
+  url.searchParams.set("additionalFields", "metrics");
+  return url.toString();
+}
+
+export function buildDuplicationBlocksUrl(componentKey: string): string {
+  const url = new URL("https://sonarcloud.io/api/duplications/show");
+  url.searchParams.set("key", componentKey);
+  return url.toString();
+}
+
+export function extractDuplicationFileSummaries(
+  response: DuplicationComponentTreeResponse,
+  projectKey: string
+): DuplicationFileSummary[] {
+  return response.components
+    .map((component) => {
+      const newDuplicatedLinesDensity = parseMeasureNumber(
+        component.measures,
+        "new_duplicated_lines_density"
+      ) ?? 0;
+      const duplicatedLines = parseMeasureNumber(
+        component.measures,
+        "duplicated_lines"
+      ) ?? 0;
+
+      return {
+        key: component.key,
+        path: component.path ?? component.key.replace(`${projectKey}:`, ""),
+        newDuplicatedLinesDensity,
+        duplicatedLines,
+      };
+    })
+    .filter(
+      (component) =>
+        component.newDuplicatedLinesDensity > 0 || component.duplicatedLines > 0
+    )
+    .sort((a, b) => {
+      if (b.newDuplicatedLinesDensity !== a.newDuplicatedLinesDensity) {
+        return b.newDuplicatedLinesDensity - a.newDuplicatedLinesDensity;
+      }
+      if (b.duplicatedLines !== a.duplicatedLines) {
+        return b.duplicatedLines - a.duplicatedLines;
+      }
+      return a.path.localeCompare(b.path);
+    });
+}
+
+export function extractDuplicationBlocks(
+  response: DuplicationBlocksResponse,
+  currentComponentKey: string
+): DuplicationBlockDetail[] {
+  const details: DuplicationBlockDetail[] = [];
+
+  for (const duplication of response.duplications ?? []) {
+    const blocks = duplication.blocks ?? [];
+    for (let leftIndex = 0; leftIndex < blocks.length - 1; leftIndex += 1) {
+      for (let rightIndex = leftIndex + 1; rightIndex < blocks.length; rightIndex += 1) {
+        const leftFile = resolveFileRef(response.files, blocks[leftIndex]._ref, currentComponentKey);
+        const rightFile = resolveFileRef(response.files, blocks[rightIndex]._ref, currentComponentKey);
+
+        if (
+          leftFile.key !== currentComponentKey &&
+          rightFile.key !== currentComponentKey
+        ) {
+          continue;
+        }
+
+        const currentBlock = leftFile.key === currentComponentKey ? blocks[leftIndex] : blocks[rightIndex];
+        const otherBlock = leftFile.key === currentComponentKey ? blocks[rightIndex] : blocks[leftIndex];
+        const otherFile = leftFile.key === currentComponentKey ? rightFile : leftFile;
+
+        const range = toRange(currentBlock);
+        const otherRange = toRange(otherBlock);
+        const sameFile = otherFile.key === currentComponentKey;
+
+        details.push({
+          range,
+          otherRange,
+          otherFileKey: otherFile.key,
+          otherFilePath: otherFile.path,
+          sameFile,
+          displayText: sameFile
+            ? `${formatRange(range)} <-> ${formatRange(otherRange)}`
+            : `${formatRange(range)} <-> ${otherFile.path}:${formatRange(otherRange)}`,
+        });
+      }
+    }
+  }
+
+  return details.sort((a, b) => {
+    if (a.range.startLine !== b.range.startLine) {
+      return a.range.startLine - b.range.startLine;
+    }
+    if (a.otherFilePath !== b.otherFilePath) {
+      return a.otherFilePath.localeCompare(b.otherFilePath);
+    }
+    return a.otherRange.startLine - b.otherRange.startLine;
+  });
+}
+
+function resolveFileRef(
+  files: Record<string, SonarDuplicationFile> | undefined,
+  ref: string | undefined,
+  fallbackKey: string
+): { key: string; path: string } {
+  const file = ref ? files?.[ref] : undefined;
+  const key = file?.key ?? fallbackKey;
+  return {
+    key,
+    path: file?.name ?? stripProjectPrefix(key),
+  };
+}
+
+function stripProjectPrefix(componentKey: string): string {
+  const separatorIndex = componentKey.indexOf(":");
+  if (separatorIndex === -1) {
+    return componentKey;
+  }
+  return componentKey.slice(separatorIndex + 1);
+}
+
+function toRange(block: SonarDuplicationBlock): DuplicationRange {
+  return {
+    startLine: block.from,
+    endLine: block.from + block.size - 1,
+  };
+}
+
+function formatRange(range: DuplicationRange): string {
+  return `L${range.startLine}-L${range.endLine}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -906,7 +906,7 @@ class SonarCloudFeedback {
 
     const files: JsonDuplicationFile[] = [];
     for (const summary of summaries) {
-      const blocksUrl = buildDuplicationBlocksUrl(summary.key);
+      const blocksUrl = buildDuplicationBlocksUrl(summary.key, prId);
       this.logApiUrl(`Duplication Blocks (${summary.path})`, blocksUrl);
       const blocksData = await this.fetchJson<DuplicationBlocksResponse>(
         blocksUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,14 @@ import {
   ComponentTreeResponse,
   extractCoverageFileDetails,
 } from "./coverage-utils";
+import {
+  buildDuplicationBlocksUrl,
+  buildDuplicationFileDetailsUrl,
+  DuplicationBlocksResponse,
+  DuplicationComponentTreeResponse,
+  extractDuplicationBlocks,
+  extractDuplicationFileSummaries,
+} from "./duplication-utils";
 import { parseMeasureNumber } from "./measure-utils";
 
 interface SonarConfig {
@@ -148,6 +156,31 @@ interface JsonIssuesSummary {
   debtTotal: number;
 }
 
+interface JsonDuplicationBlock {
+  startLine: number;
+  endLine: number;
+  otherFilePath: string;
+  otherStartLine: number;
+  otherEndLine: number;
+  sameFile: boolean;
+  displayText: string;
+}
+
+interface JsonDuplicationFile {
+  key: string;
+  path: string;
+  newDuplicatedLinesDensity: number;
+  duplicatedLines: number;
+  blocks: JsonDuplicationBlock[];
+}
+
+interface JsonDuplication {
+  newDuplicatedLinesDensity: number | null;
+  newDuplicatedLines: number | null;
+  newDuplicatedBlocks: number | null;
+  files: JsonDuplicationFile[];
+}
+
 interface JsonPrOutput {
   meta: JsonMeta;
   qualityGate: JsonQualityGate;
@@ -157,7 +190,7 @@ interface JsonPrOutput {
     total: number;
     hotspots: JsonSecurityHotspot[];
   };
-  duplication: Record<string, number | null>;
+  duplication: JsonDuplication;
   metrics: Record<string, number | null>;
 }
 
@@ -398,6 +431,14 @@ class SonarCloudFeedback {
       result[metric] = value ?? null;
     });
     return result;
+  }
+
+  private hasDuplicationFailure(qualityGate: JsonQualityGate): boolean {
+    return qualityGate.conditions.some(
+      (condition) =>
+        condition.status === "ERROR" &&
+        condition.metricKey === "new_duplicated_lines_density"
+    );
   }
 
   private handleError(error: unknown): void {
@@ -771,7 +812,10 @@ class SonarCloudFeedback {
     };
   }
 
-  private async fetchDuplicationMetrics(prId: string): Promise<Record<string, number | null>> {
+  private async fetchDuplicationMetrics(
+    prId: string,
+    includeDetails: boolean
+  ): Promise<JsonDuplication> {
     this.log(chalk.bold("\n🔄 Code Duplication"));
     this.log("-".repeat(50));
 
@@ -804,7 +848,93 @@ class SonarCloudFeedback {
       }
     });
 
-    return this.buildMetricsMap(metrics, data.component.measures);
+    const summary: JsonDuplication = {
+      newDuplicatedLinesDensity:
+        parseMeasureNumber(data.component.measures, "new_duplicated_lines_density") ?? null,
+      newDuplicatedLines:
+        parseMeasureNumber(data.component.measures, "new_duplicated_lines") ?? null,
+      newDuplicatedBlocks:
+        parseMeasureNumber(data.component.measures, "new_duplicated_blocks") ?? null,
+      files: [],
+    };
+
+    if (includeDetails) {
+      summary.files = await this.fetchDuplicationFileDetails(prId);
+      if (summary.files.length > 0) {
+        this.log("");
+        this.log("Files with new duplication:");
+        summary.files.forEach((file) => {
+          this.log(`- ${file.path}`);
+          this.log(
+            `  - new_duplicated_lines_density: ${file.newDuplicatedLinesDensity.toFixed(2)}%`
+          );
+          this.log(`  - duplicated_lines: ${file.duplicatedLines}`);
+          if (file.blocks.length === 0) {
+            this.log("  - duplicated block: unavailable");
+            return;
+          }
+          file.blocks.forEach((block) => {
+            this.log(`  - duplicated block: ${block.displayText}`);
+          });
+        });
+      }
+    }
+
+    return summary;
+  }
+
+  private async fetchDuplicationFileDetails(
+    prId: string
+  ): Promise<JsonDuplicationFile[]> {
+    const url = buildDuplicationFileDetailsUrl(
+      this.sonarConfig.projectKey,
+      this.sonarConfig.organization,
+      prId,
+      SonarCloudFeedback.COMPONENT_TREE_PAGE_SIZE
+    );
+    this.logApiUrl("Duplication File Details", url);
+
+    const data = await this.fetchJson<DuplicationComponentTreeResponse>(
+      url,
+      this.getSonarAuthHeader(),
+      "Duplication File Details"
+    );
+    const summaries = extractDuplicationFileSummaries(
+      data,
+      this.sonarConfig.projectKey
+    );
+
+    const files: JsonDuplicationFile[] = [];
+    for (const summary of summaries) {
+      const blocksUrl = buildDuplicationBlocksUrl(summary.key);
+      this.logApiUrl(`Duplication Blocks (${summary.path})`, blocksUrl);
+      const blocksData = await this.fetchJson<DuplicationBlocksResponse>(
+        blocksUrl,
+        this.getSonarAuthHeader(),
+        `Duplication Blocks (${summary.path})`
+      );
+      const blocks = extractDuplicationBlocks(blocksData, summary.key).map(
+        (block) => ({
+          startLine: block.range.startLine,
+          endLine: block.range.endLine,
+          otherFilePath: block.otherFilePath,
+          otherStartLine: block.otherRange.startLine,
+          otherEndLine: block.otherRange.endLine,
+          sameFile: block.sameFile,
+          displayText: block.displayText,
+        })
+      );
+
+      files.push({
+        key: summary.key,
+        path: summary.path,
+        newDuplicatedLinesDensity: summary.newDuplicatedLinesDensity,
+        duplicatedLines: summary.duplicatedLines,
+        blocks,
+      });
+    }
+
+    return files;
   }
 
   private async fetchCoverageMetrics(prId: string): Promise<Record<string, number | null>> {
@@ -1222,9 +1352,13 @@ class SonarCloudFeedback {
       this.log(chalk.bold("=========================================="));
 
       const qualityGate = await this.fetchQualityGate(pullRequestId);
+      const duplicationDetailsRequired = this.hasDuplicationFailure(qualityGate);
       const issuesResult = await this.fetchIssues(pullRequestId);
       const hotspotsResult = await this.fetchSecurityHotspots(pullRequestId);
-      const duplicationMetrics = await this.fetchDuplicationMetrics(pullRequestId);
+      const duplicationMetrics = await this.fetchDuplicationMetrics(
+        pullRequestId,
+        duplicationDetailsRequired
+      );
       const coverageMetrics = await this.fetchCoverageMetrics(pullRequestId);
       const overallMetrics: Record<string, number | null> = this.jsonMode
         ? await this.fetchOverallMetrics()

--- a/test/duplication-utils.test.ts
+++ b/test/duplication-utils.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert";
+import {
+  buildDuplicationBlocksUrl,
+  buildDuplicationFileDetailsUrl,
+  extractDuplicationBlocks,
+  extractDuplicationFileSummaries,
+} from "../src/duplication-utils";
+
+const componentTreeResponse = {
+  components: [
+    {
+      key: "example-project:src/duplicated.ts",
+      path: "src/duplicated.ts",
+      measures: [
+        { metric: "new_duplicated_lines_density", periods: [{ value: "25.714285714285715" }] },
+        { metric: "duplicated_lines", value: "36" },
+      ],
+    },
+    {
+      key: "example-project:src/secondary.ts",
+      measures: [
+        { metric: "new_duplicated_lines_density", periods: [{ value: "10" }] },
+        { metric: "duplicated_lines", value: "12" },
+      ],
+    },
+    {
+      key: "example-project:src/clean.ts",
+      path: "src/clean.ts",
+      measures: [
+        { metric: "new_duplicated_lines_density", periods: [{ value: "0" }] },
+        { metric: "duplicated_lines", value: "0" },
+      ],
+    },
+  ],
+};
+
+const summaries = extractDuplicationFileSummaries(
+  componentTreeResponse,
+  "example-project"
+);
+
+assert.strictEqual(summaries.length, 2);
+assert.deepStrictEqual(summaries[0], {
+  key: "example-project:src/duplicated.ts",
+  path: "src/duplicated.ts",
+  newDuplicatedLinesDensity: 25.714285714285715,
+  duplicatedLines: 36,
+});
+assert.deepStrictEqual(summaries[1], {
+  key: "example-project:src/secondary.ts",
+  path: "src/secondary.ts",
+  newDuplicatedLinesDensity: 10,
+  duplicatedLines: 12,
+});
+
+const sameFileBlocks = extractDuplicationBlocks(
+  {
+    duplications: [
+      {
+        blocks: [
+          { from: 1064, size: 36, _ref: "1" },
+          { from: 1186, size: 36, _ref: "1" },
+        ],
+      },
+    ],
+    files: {
+      "1": {
+        key: "example-project:src/duplicated.ts",
+        name: "src/duplicated.ts",
+      },
+    },
+  },
+  "example-project:src/duplicated.ts"
+);
+
+assert.deepStrictEqual(sameFileBlocks, [
+  {
+    range: { startLine: 1064, endLine: 1099 },
+    otherRange: { startLine: 1186, endLine: 1221 },
+    otherFileKey: "example-project:src/duplicated.ts",
+    otherFilePath: "src/duplicated.ts",
+    sameFile: true,
+    displayText: "L1064-L1099 <-> L1186-L1221",
+  },
+]);
+
+const crossFileBlocks = extractDuplicationBlocks(
+  {
+    duplications: [
+      {
+        blocks: [
+          { from: 40, size: 5, _ref: "1" },
+          { from: 12, size: 5, _ref: "2" },
+        ],
+      },
+    ],
+    files: {
+      "1": {
+        key: "example-project:src/current.ts",
+        name: "src/current.ts",
+      },
+      "2": {
+        key: "example-project:src/other.ts",
+        name: "src/other.ts",
+      },
+    },
+  },
+  "example-project:src/current.ts"
+);
+
+assert.deepStrictEqual(crossFileBlocks, [
+  {
+    range: { startLine: 40, endLine: 44 },
+    otherRange: { startLine: 12, endLine: 16 },
+    otherFileKey: "example-project:src/other.ts",
+    otherFilePath: "src/other.ts",
+    sameFile: false,
+    displayText: "L40-L44 <-> src/other.ts:L12-L16",
+  },
+]);
+
+const treeUrl = buildDuplicationFileDetailsUrl(
+  "example-project",
+  "example-org",
+  "123",
+  500
+);
+const treeParams = new URL(treeUrl).searchParams;
+assert.strictEqual(treeParams.get("component"), "example-project");
+assert.strictEqual(treeParams.get("organization"), "example-org");
+assert.strictEqual(treeParams.get("pullRequest"), "123");
+assert.strictEqual(treeParams.get("metricKeys"), "new_duplicated_lines_density,duplicated_lines");
+assert.strictEqual(treeParams.get("qualifiers"), "FIL");
+assert.strictEqual(treeParams.get("metricPeriod"), "1");
+assert.strictEqual(treeParams.get("ps"), "500");
+
+const duplicationUrl = buildDuplicationBlocksUrl("example-project:src/duplicated.ts");
+const duplicationParsed = new URL(duplicationUrl);
+assert.strictEqual(duplicationParsed.pathname, "/api/duplications/show");
+assert.strictEqual(
+  duplicationParsed.searchParams.get("key"),
+  "example-project:src/duplicated.ts"
+);
+
+console.log("duplication-utils tests passed");

--- a/test/duplication-utils.test.ts
+++ b/test/duplication-utils.test.ts
@@ -134,12 +134,16 @@ assert.strictEqual(treeParams.get("qualifiers"), "FIL");
 assert.strictEqual(treeParams.get("metricPeriod"), "1");
 assert.strictEqual(treeParams.get("ps"), "500");
 
-const duplicationUrl = buildDuplicationBlocksUrl("example-project:src/duplicated.ts");
+const duplicationUrl = buildDuplicationBlocksUrl(
+  "example-project:src/duplicated.ts",
+  "123"
+);
 const duplicationParsed = new URL(duplicationUrl);
 assert.strictEqual(duplicationParsed.pathname, "/api/duplications/show");
 assert.strictEqual(
   duplicationParsed.searchParams.get("key"),
   "example-project:src/duplicated.ts"
 );
+assert.strictEqual(duplicationParsed.searchParams.get("pullRequest"), "123");
 
 console.log("duplication-utils tests passed");


### PR DESCRIPTION
## 概要
- `get-sonar-feedback pr` に、`new_duplicated_lines_density` が Quality Gate failure になったときのファイル別・行別重複詳細表示を追加
- `pr --json` を追加し、重複詳細を含む構造化出力を追加
- duplication 用ユーティリティとテストを追加

## 変更内容
- `api/measures/component_tree` でファイルごとの `new_duplicated_lines_density` / `duplicated_lines` を収集
- `api/duplications/show` で重複ブロックの行範囲を収集
- 通常出力では重複ファイル一覧、各ファイルのメトリクス、重複ブロック範囲を表示
- JSON 出力では `qualityGate` / `duplication.files[].blocks[]` を含む形で返却

## 動作確認
- `npm test`
- `npm run build`
- `node dist/index.js pr --help`

Closes #38